### PR TITLE
Adding function extensions required for queueTrigger deployments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,7 @@ tag/*.csv
 
 # VSCode
 .vscode/*.json
+
+# Function extension /bin and /obj folders
+Functions/pipeline/bin
+Functions/pipeline/obj

--- a/functions/pipeline/extensions.csproj
+++ b/functions/pipeline/extensions.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+	<WarningsAsErrors></WarningsAsErrors>
+	<DefaultItemExcludes>**</DefaultItemExcludes>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" Version="1.0.1" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fixing some issues we see when deploying functions with queueTriggers now.

May need to run `func extensions install` prior to deploying.