### PR TITLE
Chron job to reset states for stale checked out images.

### DIFF
--- a/functions/pipeline/resettagstate/__init__.py
+++ b/functions/pipeline/resettagstate/__init__.py
@@ -1,0 +1,24 @@
+import datetime
+import logging
+
+import azure.functions as func
+from ..shared.db_provider import get_postgres_provider
+from ..shared.db_access import ImageTagDataAccess, ImageInfo
+
+
+def main(mytimer: func.TimerRequest) -> None:
+    utc_timestamp = datetime.datetime.utcnow().replace(
+        tzinfo=datetime.timezone.utc).isoformat()
+
+    if mytimer.past_due:
+        logging.info('The timer is past due!')
+
+    data_access = ImageTagDataAccess(get_postgres_provider())
+    # Get list of all images currently checked out, or last modified over n number of days/hours ago
+    data_access.get_stale_images()  # TODO: Rename to something else if we don't need returns.
+    # data_access.get_stale_checkedout_images() TODO:
+
+    # Set those checked out to TAGGING_INCOMPLETE ???? TODO: Or do in db_access.
+    # update_incomplete_images()
+
+    logging.info('Python timer trigger function ran at %s', utc_timestamp)

--- a/functions/pipeline/resettagstate/__init__.py
+++ b/functions/pipeline/resettagstate/__init__.py
@@ -10,15 +10,12 @@ def main(mytimer: func.TimerRequest) -> None:
     utc_timestamp = datetime.datetime.utcnow().replace(
         tzinfo=datetime.timezone.utc).isoformat()
 
-    if mytimer.past_due:
-        logging.info('The timer is past due!')
+    try:
+        data_access = ImageTagDataAccess(get_postgres_provider())
+        stale_image_ids = data_access.reset_stale_checkedout_images()
+        logging.info('Reset {} images to TAGGING_INCOMPLETE state'.format(len(stale_image_ids)))
+    except Exception as e:
+        logging.error('Error encounted while trying to reset stale image states. {}'.format(e))
+        raise
 
-    data_access = ImageTagDataAccess(get_postgres_provider())
-    # Get list of all images currently checked out, or last modified over n number of days/hours ago
-    data_access.get_stale_images()  # TODO: Rename to something else if we don't need returns.
-    # data_access.get_stale_checkedout_images() TODO:
-
-    # Set those checked out to TAGGING_INCOMPLETE ???? TODO: Or do in db_access.
-    # update_incomplete_images()
-
-    logging.info('Python timer trigger function ran at %s', utc_timestamp)
+    logging.info('Successfully ran reset function at %s', utc_timestamp)

--- a/functions/pipeline/resettagstate/function.json
+++ b/functions/pipeline/resettagstate/function.json
@@ -1,0 +1,11 @@
+{
+  "scriptFile": "__init__.py",
+  "bindings": [
+    {
+      "name": "mytimer",
+      "type": "timerTrigger",
+      "direction": "in",
+      "schedule": "0 */1 * * * *"
+    }
+  ]
+}

--- a/functions/pipeline/resettagstate/function.json
+++ b/functions/pipeline/resettagstate/function.json
@@ -5,7 +5,7 @@
       "name": "mytimer",
       "type": "timerTrigger",
       "direction": "in",
-      "schedule": "0 */1 * * * *"
+      "schedule": "0 0 * * * *"
     }
   ]
 }

--- a/functions/pipeline/resettagstate/function.json
+++ b/functions/pipeline/resettagstate/function.json
@@ -5,7 +5,7 @@
       "name": "mytimer",
       "type": "timerTrigger",
       "direction": "in",
-      "schedule": "0 0 * * * *"
+      "schedule": "0 0 0 * * *"
     }
   ]
 }

--- a/functions/pipeline/resettagstate/readme.md
+++ b/functions/pipeline/resettagstate/readme.md
@@ -1,0 +1,11 @@
+# TimerTrigger - Python
+
+The `TimerTrigger` makes it incredibly easy to have your functions executed on a schedule. This sample demonstrates a simple use case of calling your function every 5 minutes.
+
+## How it works
+
+For a `TimerTrigger` to work, you provide a schedule in the form of a [cron expression](https://en.wikipedia.org/wiki/Cron#CRON_expression)(See the link for full details). A cron expression is a string with 6 separate expressions which represent a given schedule via patterns. The pattern we use to represent every 5 minutes is `0 */5 * * * *`. This, in plain text, means: "When seconds is equal to 0, minutes is divisible by 5, for any hour, day of the month, month, day of the week, or year".
+
+## Learn more
+
+<TODO> Documentation

--- a/functions/pipeline/shared/db_access/db_access_v2.py
+++ b/functions/pipeline/shared/db_access/db_access_v2.py
@@ -231,7 +231,7 @@ class ImageTagDataAccess(object):
         return list(image_id_to_image_labels.values())
 
     
-    def get_stale_images(self):
+    def reset_stale_checkedout_images(self):
         stale_image_ids = []
         try:
             conn = self._db_provider.get_connection()

--- a/functions/pipeline/shared/db_access/db_access_v2.py
+++ b/functions/pipeline/shared/db_access/db_access_v2.py
@@ -230,6 +230,36 @@ class ImageTagDataAccess(object):
             conn.close()
         return list(image_id_to_image_labels.values())
 
+    
+    def get_stale_images(self):
+        stale_image_ids = []
+        try:
+            conn = self._db_provider.get_connection()
+            try:
+                cursor = conn.cursor()
+                query = ("SELECT imageid, tagstateid, modifieddtim "
+                            "FROM image_tagging_state "
+                            "WHERE tagstateid = 2 AND modifieddtim < now() - interval '24 hour' "
+                            "order by modifieddtim ASC;")
+                cursor.execute(query.format(ImageTagState.TAG_IN_PROGRESS))
+                for row in cursor:
+                    logging.debug('Image Id: {0} \t\ttagstateid: {1} \t\tmodifieddtim: {2}'.format(row[0], row[1], row[2]))
+                    stale_image_ids.append(row[0])
+                for stale_image_id in stale_image_ids:
+                    logging.info('stale image id: {}'.format(stale_image_id))
+
+                chron_user_id = self.create_user('chron_job_user')
+                self._update_images(stale_image_ids,ImageTagState.INCOMPLETE_TAG, chron_user_id, conn)
+            finally:
+                cursor.close()
+        except Exception as e:
+            logging.error("An errors occured getting images: {0}".format(e))
+            raise
+        finally:
+            conn.close()
+        return stale_image_ids
+
+
     def get_existing_classifications(self):
         try:
             conn = self._db_provider.get_connection()

--- a/functions/pipeline/shared/db_access/db_access_v2.py
+++ b/functions/pipeline/shared/db_access/db_access_v2.py
@@ -245,9 +245,6 @@ class ImageTagDataAccess(object):
                 for row in cursor:
                     logging.debug('Image Id: {0} \t\ttagstateid: {1} \t\tmodifieddtim: {2}'.format(row[0], row[1], row[2]))
                     stale_image_ids.append(row[0])
-                for stale_image_id in stale_image_ids:
-                    logging.info('stale image id: {}'.format(stale_image_id))
-
                 chron_user_id = self.create_user('chron_job_user')
                 self._update_images(stale_image_ids,ImageTagState.INCOMPLETE_TAG, chron_user_id, conn)
             finally:

--- a/functions/pipeline/shared/db_access/db_access_v2.py
+++ b/functions/pipeline/shared/db_access/db_access_v2.py
@@ -253,7 +253,7 @@ class ImageTagDataAccess(object):
             finally:
                 cursor.close()
         except Exception as e:
-            logging.error("An errors occured getting images: {0}".format(e))
+            logging.error("An error occured while returning stale checkedout images to incomplete tagging state: {0}".format(e))
             raise
         finally:
             conn.close()

--- a/functions/pipeline/shared/db_access/db_access_v2.py
+++ b/functions/pipeline/shared/db_access/db_access_v2.py
@@ -239,7 +239,7 @@ class ImageTagDataAccess(object):
                 cursor = conn.cursor()
                 query = ("SELECT imageid, tagstateid, modifieddtim "
                             "FROM image_tagging_state "
-                            "WHERE tagstateid = 2 AND modifieddtim < now() - interval '24 hour' "
+                            "WHERE tagstateid = 2 AND modifieddtim < now() - interval '3 day' "
                             "order by modifieddtim ASC;")
                 cursor.execute(query.format(ImageTagState.TAG_IN_PROGRESS))
                 for row in cursor:


### PR DESCRIPTION
Currently runs every day at midnight UTC, will check for images that are checked out more than 3 days ago, and reset those to TAGGING_INCOMPLETE state.